### PR TITLE
chore: Update pyproject.toml to use PEP639 license specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "pado-optics"
 version = "1.0.1"
 description = "Pytorch Automatic Differentiable Optics"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [
     { name = "Seung-Hwan Baek", email = "shwbaek@postech.ac.kr" },
     { name = "Dong-Ha Shin", email = "0218sdh@gmail.com"  },


### PR DESCRIPTION
Updates the license specifications in `pyproject.toml` to meet the new PEP639 standards.

## References:
- https://peps.python.org/pep-0639/#abstract
- https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-files